### PR TITLE
feat: persist language preference across sessions + fix mobile login …

### DIFF
--- a/app.py
+++ b/app.py
@@ -98,7 +98,7 @@ def _ensure_telegram_columns():
     try:
         from tenant_utils import get_db
         conn = get_db()
-        for col in ['telegram_chat_id TEXT', 'telegram_link_token TEXT']:
+        for col in ['telegram_chat_id TEXT', 'telegram_link_token TEXT', 'preferred_lang TEXT DEFAULT "en"']:
             try:
                 conn.execute(f'ALTER TABLE sales_team ADD COLUMN {col}')
             except Exception:
@@ -155,6 +155,17 @@ def login_redirect():
 def change_lang(lang):
     if lang in ['en', 'ar']:
         session['lang'] = lang
+        if 'salesperson_id' in session:
+            try:
+                conn = get_db()
+                conn.execute(
+                    "UPDATE sales_team SET preferred_lang = ? WHERE salesperson_id = ?",
+                    (lang, session['salesperson_id'])
+                )
+                conn.commit()
+                conn.close()
+            except Exception:
+                pass
     return redirect(request.referrer or '/')
 
 # Add ProxyFix middleware

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -32,8 +32,8 @@ def login():
 
             # Check sales_team table for user
             cursor.execute("""
-                SELECT salesperson_id, username, first_name, role, tenant_id, password 
-                FROM sales_team 
+                SELECT salesperson_id, username, first_name, role, tenant_id, password, preferred_lang
+                FROM sales_team
                 WHERE username = ? AND tenant_id = ?
             """, (username, tenant['id']))
 
@@ -54,6 +54,7 @@ def login():
             session['salesperson_name'] = user['first_name']
             session['role'] = user['role']
             session['tenant_id'] = user['tenant_id']
+            session['lang'] = user['preferred_lang'] or 'en'
 
             # Redirect based on role
             if user['role'] in ['admin', 'manager']:

--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="{{ session.get('lang', 'en') }}" dir="{{ 'rtl' if session.get('lang') == 'ar' else 'ltr' }}">
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ _('Welcome') }}</title>
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='img/my_logo.png') }}">
     <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
…viewport

- Add preferred_lang column to sales_team via safe migration
- Save language to DB on change, restore it from DB on login
- Add viewport meta tag to login page so it renders correctly on mobile