### PR TITLE
feat(accounts): add individual vs company account types

### DIFF
--- a/app.py
+++ b/app.py
@@ -94,7 +94,7 @@ app.register_blueprint(quotations_bp)
 app.register_blueprint(profile_bp)
 
 def _ensure_telegram_columns():
-    """Safe migration: add Telegram columns to sales_team if missing."""
+    """Safe migration: add missing columns to sales_team and tenants."""
     try:
         from tenant_utils import get_db
         conn = get_db()
@@ -103,6 +103,10 @@ def _ensure_telegram_columns():
                 conn.execute(f'ALTER TABLE sales_team ADD COLUMN {col}')
             except Exception:
                 pass
+        try:
+            conn.execute("ALTER TABLE tenants ADD COLUMN account_type TEXT DEFAULT 'company'")
+        except Exception:
+            pass
         conn.commit()
         conn.close()
     except Exception:

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -24,7 +24,7 @@ def login():
 
         try:
             # Get tenant by db_key
-            cursor.execute("SELECT id, name FROM tenants WHERE db_key = ?", (db_key,))
+            cursor.execute("SELECT id, name, account_type FROM tenants WHERE db_key = ?", (db_key,))
             tenant = cursor.fetchone()
 
             if not tenant:
@@ -55,6 +55,7 @@ def login():
             session['role'] = user['role']
             session['tenant_id'] = user['tenant_id']
             session['lang'] = user['preferred_lang'] or 'en'
+            session['account_type'] = tenant['account_type'] or 'company'
 
             # Redirect based on role
             if user['role'] in ['admin', 'manager']:

--- a/routes/users.py
+++ b/routes/users.py
@@ -1,17 +1,26 @@
-from flask import Blueprint, render_template, request, redirect, url_for, session
+from flask import Blueprint, render_template, request, redirect, url_for, session, abort
 import sqlite3
 from tenant_utils import get_db, get_current_tenant_id, require_tenant
 from security import bcrypt, csrf
 from flask_wtf.csrf import CSRFError
+from functools import wraps
 
-# Create a Blueprint for user management routes
 users_bp = Blueprint('users', __name__)
+
+def require_company_account(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        if session.get('account_type') == 'individual':
+            abort(403)
+        return f(*args, **kwargs)
+    return decorated
 
 @users_bp.errorhandler(CSRFError)
 def handle_csrf_error(e):
     return render_template('sales_team/add_salesperson.html', error="CSRF token validation failed. Please try again."), 400
 
 @users_bp.route('/salespeople/add', methods=['GET', 'POST'])
+@require_company_account
 @require_tenant
 def add_salesperson():
     if 'salesperson_id' in session and session.get('role') in ['admin', 'manager']: # Allow both admin and manager
@@ -68,6 +77,7 @@ def add_salesperson():
     return redirect(url_for('auth.login'))
 
 @users_bp.route('/salespeople')
+@require_company_account
 @require_tenant
 def salespeople_list():
     if 'salesperson_id' in session and session.get('role') in ['admin', 'manager']: # Allow both admin and manager
@@ -100,6 +110,7 @@ def salespeople_list():
     return redirect(url_for('auth.login'))
 
 @users_bp.route('/salespeople/<int:salesperson_id>/data')
+@require_company_account
 @require_tenant
 def get_salesperson_data(salesperson_id):
     if 'salesperson_id' in session and session.get('role') in ['admin', 'manager']: # Allow both admin and manager
@@ -132,6 +143,7 @@ def get_salesperson_data(salesperson_id):
     return {'error': 'Unauthorized'}, 401
 
 @users_bp.route('/salespeople/edit', methods=['POST'])
+@require_company_account
 @require_tenant
 def edit_salesperson():
     if 'salesperson_id' in session and session.get('role') in ['admin', 'manager']: # Allow both admin and manager
@@ -174,6 +186,7 @@ def edit_salesperson():
     return redirect(url_for('auth.login'))
 
 @users_bp.route('/salespeople/change-password', methods=['POST'])
+@require_company_account
 @require_tenant
 def change_password():
     if 'salesperson_id' in session and session.get('role') in ['admin', 'manager']: # Allow both admin and manager

--- a/templates/components/sidebar.html
+++ b/templates/components/sidebar.html
@@ -127,20 +127,21 @@
 
     <div class="sb-divider"></div>
 
-    {# ── Team (future) ── #}
-    {% if session.get('role') in ['admin', 'manager'] %}
-    <a href="{{ url_for('users.salespeople_list') }}"
-       class="sb-item {% if request.endpoint and 'salespeople' in request.endpoint %}active{% endif %}">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
-      <span class="sb-label">{{ _('Sales Team') }}</span>
-    </a>
+    {# ── Team & Permissions — company accounts only ── #}
+    {% if session.get('account_type') == 'company' %}
+      {% if session.get('role') in ['admin', 'manager'] %}
+      <a href="{{ url_for('users.salespeople_list') }}"
+         class="sb-item {% if request.endpoint and 'salespeople' in request.endpoint %}active{% endif %}">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+        <span class="sb-label">{{ _('Sales Team') }}</span>
+      </a>
+      {% endif %}
+      <a href="#" class="sb-item sb-soon">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="11" x="3" y="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+        <span class="sb-label">{{ _('Permissions') }}</span>
+        <span class="sb-badge">soon</span>
+      </a>
     {% endif %}
-
-    <a href="#" class="sb-item sb-soon">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="11" x="3" y="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
-      <span class="sb-label">{{ _('Permissions') }}</span>
-      <span class="sb-badge">soon</span>
-    </a>
 
     <div class="sb-divider"></div>
 


### PR DESCRIPTION
- Auto-migrate tenants table with account_type column (default: company)
- Load account_type into session on login
- Hide Sales Team and Permissions from sidebar for individual accounts
- Block /salespeople* routes with 403 for individual accounts