### PR TITLE
feat(individual): redirect to regular dashboard + Sales Analytics sub…

### DIFF
--- a/app.py
+++ b/app.py
@@ -206,7 +206,8 @@ def manifest():
 @app.route('/')
 def index():
     if 'salesperson_id' in session:
-        if session.get('role') in ['admin', 'manager']:
+        is_individual = session.get('account_type') == 'individual'
+        if session.get('role') in ['admin', 'manager'] and not is_individual:
             return redirect(url_for('dashboard.manager_dashboard'))
         return redirect(url_for('dashboard.dashboard'))
     return redirect(url_for('auth.login'))

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -57,8 +57,9 @@ def login():
             session['lang'] = user['preferred_lang'] or 'en'
             session['account_type'] = tenant['account_type'] or 'company'
 
-            # Redirect based on role
-            if user['role'] in ['admin', 'manager']:
+            # Redirect based on role and account type
+            is_individual = (tenant['account_type'] or 'company') == 'individual'
+            if user['role'] in ['admin', 'manager'] and not is_individual:
                 return redirect(url_for('dashboard.manager_dashboard'))
             return redirect(url_for('dashboard.dashboard'))
 

--- a/templates/components/sidebar.html
+++ b/templates/components/sidebar.html
@@ -53,6 +53,13 @@
           <span class="sb-label">{{ _('Deals') }}</span>
           <span class="sb-badge">soon</span>
         </a>
+        {% if session.get('account_type') == 'individual' and session.get('role') in ['admin', 'manager'] %}
+        <a href="{{ url_for('dashboard.manager_dashboard') }}"
+           class="sb-item {% if request.endpoint in ['dashboard.manager_dashboard','dashboard.admin_dashboard'] %}active{% endif %}">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 7 13.5 15.5 8.5 10.5 2 17"/><polyline points="16 7 22 7 22 13"/></svg>
+          <span class="sb-label">{{ _('Sales Analytics') }}</span>
+        </a>
+        {% endif %}
         <a href="{{ url_for('quotations.quotation_list') }}"
            class="sb-item {% if request.endpoint and 'quotation' in request.endpoint %}active{% endif %}">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>


### PR DESCRIPTION
…-tab

- Individual admins land on regular dashboard after login (not manager dashboard)
- Add 'Sales Analytics' sub-tab under Sales for individual admins linking to manager_dashboard