### PR TITLE
feat(customers): redesign list page + delete endpoint + bi-directiona…

### DIFF
--- a/routes/companies.py
+++ b/routes/companies.py
@@ -94,8 +94,17 @@ def add_company():
                 request.form.get('website', '').strip(),
                 tenant_id
             ))
-            log_activity(conn, tenant_id, 'company', cur.lastrowid, 'created',
+            new_company_id = cur.lastrowid
+            log_activity(conn, tenant_id, 'company', new_company_id, 'created',
                          f'Company "{name}" created')
+            # Auto-link any existing customers whose company_name matches
+            conn.execute(
+                """UPDATE customers
+                   SET company_id = ?
+                   WHERE LOWER(company_name) = LOWER(?) AND tenant_id = ?
+                     AND (company_id IS NULL OR company_id = 0)""",
+                (new_company_id, name, tenant_id)
+            )
             conn.commit()
         finally:
             conn.close()

--- a/routes/customers.py
+++ b/routes/customers.py
@@ -246,12 +246,13 @@ def customer_list():
             sales_stages.append('N/A')
 
         conn.close()
-        return render_template('customers/customer_list.html', 
-                             customers=customers, 
+        return render_template('customers/customer_list.html',
+                             customers=customers,
+                             total=total_customers,
                              search_term=search_term,
-                             sort_by=sort_by, 
-                             order=order, 
-                             page=page, 
+                             sort_by=sort_by,
+                             order=order,
+                             page=page,
                              total_pages=total_pages,
                              sales_stages=sales_stages,
                              current_stage=request.args.get('stage', ''))
@@ -290,21 +291,40 @@ def add_customer():
                 assigned_salesperson_id = request.form.get('assigned_salesperson_id', salesperson_id)
 
             try:
+                # Auto-create or find matching company ─────────────────
+                tid = get_current_tenant_id()
+                auto_company_id = None
+                if company_name:
+                    existing_co = conn.execute(
+                        "SELECT id FROM companies WHERE LOWER(name) = LOWER(?) AND tenant_id = ?",
+                        (company_name, tid)
+                    ).fetchone()
+                    if existing_co:
+                        auto_company_id = existing_co['id']
+                    else:
+                        cur_co = conn.execute(
+                            "INSERT INTO companies (name, industry, phone, tenant_id) VALUES (?,?,?,?)",
+                            (company_name, company_industry, phone_number, tid)
+                        )
+                        auto_company_id = cur_co.lastrowid
+                        log_activity(conn, tid, 'company', auto_company_id, 'created',
+                                     f'Auto-created from customer "{company_name}"')
+                # ─────────────────────────────────────────────────────────
                 cursor.execute('''
                     INSERT INTO customers (
                         company_name, company_industry, contact_person,
                         contact_person_position, phone_number, email_address,
                         company_address, lead_source, initial_interest,
-                        date_added, assigned_salesperson_id, tenant_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        date_added, assigned_salesperson_id, tenant_id, company_id
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ''', (
                     company_name, company_industry, contact_person,
                     contact_person_position, phone_number, email_address,
                     company_address, lead_source, initial_interest,
-                    date_added, assigned_salesperson_id, get_current_tenant_id()
+                    date_added, assigned_salesperson_id, tid, auto_company_id
                 ))
                 customer_id = cursor.lastrowid
-                log_activity(conn, get_current_tenant_id(), 'customer', customer_id, 'created',
+                log_activity(conn, tid, 'customer', customer_id, 'created',
                              f'Customer "{company_name}" added')
                 conn.commit()
                 return redirect(url_for('customers.customer_detail', customer_id=customer_id))
@@ -476,12 +496,34 @@ def edit_customer(customer_id):
             cursor.execute("SELECT assigned_salesperson_id FROM customers WHERE customer_id = ?", (customer_id,))
             assigned_salesperson_id = cursor.fetchone()['assigned_salesperson_id']
 
+            # Auto-create or find matching company ─────────────────
+            tid = get_current_tenant_id()
+            auto_company_id = None
+            if company_name:
+                existing_co = conn.execute(
+                    "SELECT id FROM companies WHERE LOWER(name) = LOWER(?) AND tenant_id = ?",
+                    (company_name, tid)
+                ).fetchone()
+                if existing_co:
+                    auto_company_id = existing_co['id']
+                else:
+                    cur_co = conn.execute(
+                        "INSERT INTO companies (name, industry, phone, tenant_id) VALUES (?,?,?,?)",
+                        (company_name, company_industry, phone_number, tid)
+                    )
+                    auto_company_id = cur_co.lastrowid
+                    log_activity(conn, tid, 'company', auto_company_id, 'created',
+                                 f'Auto-created from customer "{company_name}"')
+            # ─────────────────────────────────────────────────────────
             cursor.execute('''
                 UPDATE customers SET company_name=?, contact_person=?, phone_number=?, email_address=?,
-                company_address=?, lead_source=?, initial_interest=?, company_industry=?, contact_person_position=?, assigned_salesperson_id=?
+                company_address=?, lead_source=?, initial_interest=?, company_industry=?,
+                contact_person_position=?, assigned_salesperson_id=?, company_id=?
                 WHERE customer_id=?
-            ''', (company_name, contact_person, phone_number, email_address, company_address, lead_source, initial_interest, company_industry, contact_person_position, assigned_salesperson_id, customer_id))
-            log_activity(conn, get_current_tenant_id(), 'customer', customer_id, 'updated',
+            ''', (company_name, contact_person, phone_number, email_address, company_address,
+                  lead_source, initial_interest, company_industry, contact_person_position,
+                  assigned_salesperson_id, auto_company_id, customer_id))
+            log_activity(conn, tid, 'customer', customer_id, 'updated',
                          f'Customer "{company_name}" updated')
             conn.commit()
             conn.close()
@@ -598,5 +640,35 @@ def quick_add():
     except Exception as e:
         conn.rollback()
         return jsonify({'error': str(e)}), 500
+    finally:
+        conn.close()
+
+
+@customers_bp.route('/<int:customer_id>/delete', methods=['POST'])
+@require_tenant
+def delete_customer(customer_id):
+    """AJAX delete — removes follow-ups, project links, then the customer row."""
+    if 'salesperson_id' not in session:
+        return jsonify({'error': 'Unauthorized'}), 403
+    tenant_id = get_current_tenant_id()
+    conn = get_db()
+    try:
+        # verify ownership
+        row = conn.execute(
+            "SELECT customer_id FROM customers WHERE customer_id = ? AND tenant_id = ?",
+            (customer_id, tenant_id)
+        ).fetchone()
+        if not row:
+            return jsonify({'success': False, 'message': 'Not found'}), 404
+        conn.execute("DELETE FROM sales_followup   WHERE customer_id = ? AND tenant_id = ?",
+                     (customer_id, tenant_id))
+        conn.execute("DELETE FROM project_contacts WHERE customer_id = ?", (customer_id,))
+        conn.execute("DELETE FROM customers         WHERE customer_id = ? AND tenant_id = ?",
+                     (customer_id, tenant_id))
+        conn.commit()
+        return jsonify({'success': True})
+    except sqlite3.Error as e:
+        conn.rollback()
+        return jsonify({'success': False, 'message': str(e)}), 500
     finally:
         conn.close()

--- a/templates/customers/customer_list.html
+++ b/templates/customers/customer_list.html
@@ -1,491 +1,354 @@
 {% extends "base.html" %}
-
 {% block title %}{{ _('Customers') }}{% endblock %}
 
 {% block extra_styles %}
 <style>
-    :root {
-        --primary-color: #2563eb;
-        --secondary-color: #64748b;
-        --success-color: #22c55e;
-        --background-color: #f8fafc;
-        --card-background: #ffffff;
-        --border-color: #e2e8f0;
-        --text-primary: #1e293b;
-        --text-secondary: #64748b;
-    }
+  .page-header {
+    display: flex; justify-content: space-between; align-items: center;
+    margin-bottom: 1.5rem; flex-wrap: wrap; gap: 1rem;
+  }
+  .page-title { font-size: 1.6rem; font-weight: 700; color: var(--text-primary); }
+  .page-title span { font-size: 0.9rem; font-weight: 400; color: var(--text-secondary); margin-inline-start: 0.5rem; }
+  .toolbar { display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap; }
 
-    .container {
-        max-width: 1400px;
-        margin: 0 auto;
-        padding: 2rem;
-    }
+  .search-box { position: relative; }
+  .search-box input {
+    padding: 0.55rem 0.9rem 0.55rem 2.4rem;
+    border: 1.5px solid var(--border-color); border-radius: 8px;
+    font-size: 0.875rem; width: 220px; background: #fff; transition: border-color .2s; font-family: inherit;
+  }
+  [dir="rtl"] .search-box input { padding: 0.55rem 2.4rem 0.55rem 0.9rem; }
+  .search-box input:focus { outline: none; border-color: var(--primary-color); }
+  .search-box svg { position: absolute; top:50%; left:0.7rem; transform:translateY(-50%); color:var(--text-secondary); pointer-events:none; }
+  [dir="rtl"] .search-box svg { left:auto; right:0.7rem; }
 
-    .header {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        margin-bottom: 2rem;
-    }
+  .filter-select {
+    padding: 0.55rem 0.75rem; border: 1.5px solid var(--border-color);
+    border-radius: 8px; font-size: 0.875rem; background: #fff; font-family: inherit; cursor: pointer;
+  }
+  .filter-select:focus { outline: none; border-color: var(--primary-color); }
 
-    .page-title {
-        font-size: 2rem;
-        font-weight: 600;
-        color: var(--text-primary);
-    }
+  .btn {
+    display: inline-flex; align-items: center; gap: 0.4rem;
+    padding: 0.55rem 1rem; border-radius: 8px; font-size: 0.875rem;
+    font-weight: 500; cursor: pointer; border: none; text-decoration: none; transition: all .2s; font-family: inherit;
+  }
+  .btn-primary { background: var(--primary-color); color: #fff; }
+  .btn-primary:hover { background: #1d4ed8; }
+  .btn-outline { background: #fff; color: var(--text-primary); border: 1.5px solid var(--border-color); }
+  .btn-outline:hover { border-color: var(--primary-color); color: var(--primary-color); }
+  .btn-danger  { background: #ef4444; color: #fff; }
+  .btn-danger:hover  { background: #dc2626; }
+  .btn-success { background: #16a34a; color: #fff; }
+  .btn-success:hover { background: #15803d; }
+  .btn-sm { padding: 0.35rem 0.7rem; font-size: 0.8rem; }
 
-    .action-buttons {
-        display: flex;
-        gap: 1rem;
-    }
+  /* View toggle */
+  .view-toggle { display: flex; gap: 2px; background: #f1f5f9; border-radius: 8px; padding: 3px; }
+  .view-btn {
+    padding: 0.35rem 0.6rem; border-radius: 6px; cursor: pointer;
+    border: none; background: transparent; color: var(--text-secondary);
+    display: flex; align-items: center; transition: all .15s;
+  }
+  .view-btn.active { background: #fff; color: var(--primary-color); box-shadow: 0 1px 3px rgba(0,0,0,.1); }
 
-    /* Updated Button Styles */
-    .btn {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        gap: 0.5rem;
-        padding: 0.75rem 1.25rem;
-        border-radius: 0.5rem;
-        font-weight: 500;
-        font-size: 0.875rem;
-        cursor: pointer;
-        transition: all 0.2s ease;
-        text-decoration: none;
-        border: none;
-        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-    }
+  /* Cards grid */
+  .cards-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(290px, 1fr));
+    gap: 1.25rem;
+  }
+  .customer-card {
+    background: #fff; border: 1.5px solid var(--border-color);
+    border-radius: 12px; padding: 1.25rem;
+    transition: box-shadow .2s, border-color .2s;
+    cursor: pointer;
+  }
+  .customer-card:hover { box-shadow: 0 4px 16px rgba(0,0,0,.08); border-color: var(--primary-color); }
 
-    .btn-primary {
-        background-color: var(--primary-color);
-        color: white;
-    }
+  .card-top { display: flex; align-items: flex-start; gap: 0.9rem; margin-bottom: 0.9rem; }
+  .card-avatar {
+    width: 44px; height: 44px; border-radius: 10px; flex-shrink: 0;
+    background: linear-gradient(135deg, #dbeafe, #ede9fe);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 1.15rem; font-weight: 700; color: var(--primary-color);
+  }
+  .card-info { flex: 1; min-width: 0; }
+  .card-name { font-size: 1rem; font-weight: 600; color: var(--text-primary); margin-bottom: 1px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .card-contact { font-size: 0.8rem; color: var(--text-secondary); }
 
-    .btn-primary:hover {
-        background-color: #1d4ed8;
-        transform: translateY(-1px);
-        box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-    }
+  .stage-badge {
+    display: inline-block; padding: 2px 9px; border-radius: 20px;
+    font-size: 0.75rem; font-weight: 500; white-space: nowrap; flex-shrink: 0;
+    background: #f1f5f9; color: #475569;
+  }
+  .stage-won  { background: #dcfce7; color: #15803d; }
+  .stage-lost { background: #fee2e2; color: #991b1b; }
+  .stage-hot  { background: #fef9c3; color: #92400e; }
+  .stage-new  { background: #eff6ff; color: #1d4ed8; }
 
-    .btn-secondary {
-        background-color: var(--secondary-color);
-        color: white;
-    }
+  .card-meta { display: flex; flex-wrap: wrap; gap: 0.75rem; margin-bottom: 0.9rem; }
+  .meta-chip { display: flex; align-items: center; gap: 0.3rem; font-size: 0.78rem; color: var(--text-secondary); }
+  .meta-chip svg { flex-shrink: 0; }
 
-    .btn-secondary:hover {
-        background-color: #475569;
-        transform: translateY(-1px);
-        box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-    }
+  .card-footer {
+    padding-top: 0.9rem; border-top: 1px solid var(--border-color);
+    display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; flex-wrap: wrap;
+  }
+  .card-value { font-size: 0.82rem; font-weight: 600; color: #16a34a; }
+  .card-date  { font-size: 0.78rem; color: var(--text-secondary); }
+  .card-actions { display: flex; gap: 0.4rem; }
 
-    .btn-success {
-        background-color: var(--success-color);
-        color: white;
-    }
+  /* List view */
+  .list-table-wrap { background: #fff; border-radius: 12px; border: 1.5px solid var(--border-color); overflow: hidden; }
+  table { width: 100%; border-collapse: collapse; }
+  thead { background: #f8fafc; }
+  th { padding: 0.85rem 1rem; font-size: 0.78rem; font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing:.05em; text-align: start; }
+  td { padding: 0.9rem 1rem; font-size: 0.875rem; color: var(--text-primary); border-top: 1px solid var(--border-color); vertical-align: middle; }
+  tr:hover td { background: #f8fafc; }
+  .td-name { font-weight: 600; }
+  .td-name a { color: var(--text-primary); text-decoration: none; }
+  .td-name a:hover { color: var(--primary-color); }
+  .badge { display: inline-block; padding: 2px 8px; border-radius: 20px; font-size: 0.75rem; font-weight: 500; }
 
-    .btn-success:hover {
-        background-color: #16a34a;
-        transform: translateY(-1px);
-        box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-    }
+  /* Empty */
+  .empty-state { text-align: center; padding: 4rem 2rem; color: var(--text-secondary); }
+  .empty-state svg { opacity: .3; margin-bottom: 1rem; }
+  .empty-state p { font-size: 1rem; }
 
-    .btn-icon {
-        padding: 0.5rem;
-        min-width: 2.5rem;
-        height: 2.5rem;
-    }
+  /* Pagination */
+  .pagination { display: flex; align-items: center; justify-content: center; gap: 0.4rem; margin-top: 1.5rem; }
+  .page-link {
+    padding: 0.45rem 0.8rem; border-radius: 7px; font-size: 0.875rem;
+    text-decoration: none; color: var(--text-primary);
+    border: 1.5px solid var(--border-color); background: #fff; transition: all .15s;
+  }
+  .page-link:hover { border-color: var(--primary-color); color: var(--primary-color); }
+  .page-link.active { background: var(--primary-color); color: #fff; border-color: var(--primary-color); }
+  .page-link.disabled { opacity: .4; pointer-events: none; }
 
-    .btn-block {
-        width: 100%;
-    }
-
-    .search-filter-container {
-        display: flex;
-        gap: 1rem;
-        margin-bottom: 2rem;
-        flex-wrap: wrap;
-    }
-
-    .search-box {
-        flex: 1;
-        min-width: min(300px, 100%);
-        padding: 0.75rem 1rem;
-        border: 1px solid var(--border-color);
-        border-radius: 0.5rem;
-        font-size: 1rem;
-        transition: border-color 0.2s;
-        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%2364748b' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='11' cy='11' r='8'%3E%3C/circle%3E%3Cline x1='21' y1='21' x2='16.65' y2='16.65'%3E%3C/line%3E%3C/svg%3E");
-        background-repeat: no-repeat;
-        background-position: 12px center;
-        padding-left: 40px;
-    }
-
-    .search-box:focus {
-        outline: none;
-        border-color: var(--primary-color);
-    }
-
-    .filter-select {
-        padding: 0.75rem 1rem;
-        border: 1px solid var(--border-color);
-        border-radius: 0.5rem;
-        background-color: white;
-        color: var(--text-primary);
-        font-size: 1rem;
-        min-width: min(200px, 100%);
-        cursor: pointer;
-        transition: border-color 0.2s;
-    }
-
-    .filter-select:focus {
-        outline: none;
-        border-color: var(--primary-color);
-    }
-
-    .customer-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(min(300px, 100%), 1fr));
-        gap: 1.5rem;
-        margin-bottom: 2rem;
-    }
-
-    .customer-card {
-        background-color: var(--card-background);
-        border-radius: 0.75rem;
-        padding: 1.5rem;
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-        transition: all 0.2s ease;
-    }
-
-    .customer-card:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-    }
-
-    .customer-header {
-        display: flex;
-        justify-content: space-between;
-        align-items: flex-start;
-        margin-bottom: 1rem;
-        padding-bottom: 0.75rem;
-        border-bottom: 1px solid var(--border-color);
-    }
-
-    .customer-name {
-        font-size: 1.25rem;
-        font-weight: 600;
-        color: var(--text-primary);
-        text-decoration: none;
-        transition: color 0.2s ease;
-    }
-
-    .customer-name:hover {
-        color: var(--primary-color);
-    }
-
-    .customer-stage {
-        padding: 0.375rem 0.75rem;
-        border-radius: 0.5rem;
-        font-size: 0.875rem;
-        font-weight: 500;
-        background-color: var(--background-color);
-        color: var(--text-secondary);
-        border: 1px solid var(--border-color);
-    }
-
-    .customer-info {
-        display: grid;
-        gap: 0.75rem;
-    }
-
-    .info-row {
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-    }
-
-    .info-label {
-        color: var(--text-secondary);
-        font-size: 0.875rem;
-        min-width: 100px;
-    }
-
-    .info-value {
-        color: var(--text-primary);
-        font-size: 0.875rem;
-    }
-
-    .customer-actions {
-        display: flex;
-        gap: 0.75rem;
-        margin-top: 1.5rem;
-        padding-top: 1rem;
-        border-top: 1px solid var(--border-color);
-    }
-
-    .potential-value {
-        font-weight: 600;
-        color: var(--success-color);
-        display: inline-flex;
-        align-items: center;
-        gap: 0.25rem;
-    }
-
-    .potential-value::before {
-        content: "💰";
-    }
-
-    .pagination {
-        display: flex;
-        justify-content: center;
-        gap: 0.5rem;
-        margin-top: 2rem;
-    }
-
-    .page-item {
-        list-style: none;
-    }
-
-    .page-link {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        min-width: 2.5rem;
-        height: 2.5rem;
-        padding: 0 1rem;
-        border: 1px solid var(--border-color);
-        border-radius: 0.5rem;
-        color: var(--text-primary);
-        text-decoration: none;
-        transition: all 0.2s ease;
-        background-color: var(--card-background);
-    }
-
-    .page-link:hover {
-        background-color: var(--background-color);
-        border-color: var(--primary-color);
-        transform: translateY(-1px);
-    }
-
-    .page-link.active {
-        background-color: var(--primary-color);
-        border-color: var(--primary-color);
-        color: white;
-    }
-
-    .empty-state {
-        text-align: center;
-        padding: 3rem;
-        background-color: var(--card-background);
-        border-radius: 0.75rem;
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-    }
-
-    .empty-state-icon {
-        font-size: 3rem;
-        margin-bottom: 1rem;
-        color: var(--text-secondary);
-    }
-
-    .empty-state h2 {
-        color: var(--text-primary);
-        margin-bottom: 0.5rem;
-    }
-
-    .empty-state p {
-        color: var(--text-secondary);
-    }
-
-    .dashboard-link {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.5rem;
-        padding: 0.75rem 1.25rem;
-        border-radius: 0.5rem;
-        background-color: var(--secondary-color);
-        color: white;
-        text-decoration: none;
-        font-weight: 500;
-        transition: all 0.2s ease;
-        border: none;
-        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-    }
-
-    .dashboard-link:hover {
-        background-color: #475569;
-        transform: translateY(-1px);
-        box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-    }
-
-    @media (max-width: 768px) {
-        .container {
-            padding: 1rem;
-        }
-
-        .header {
-            flex-direction: column;
-            gap: 1rem;
-            align-items: flex-start;
-        }
-
-        .action-buttons {
-            width: 100%;
-            justify-content: space-between;
-        }
-
-        .btn {
-            flex: 1;
-        }
-
-        .search-filter-container {
-            flex-direction: column;
-        }
-
-        .search-box,
-        .filter-select {
-            width: 100%;
-        }
-
-        .customer-grid {
-            grid-template-columns: 1fr;
-        }
-    }
+  @media (max-width: 640px) {
+    .toolbar { gap: 0.5rem; }
+    .search-box input { width: 160px; }
+    .cards-grid { grid-template-columns: 1fr; }
+  }
 </style>
 {% endblock %}
 
 {% block content %}
-<div class="container">
-    <div class="header">
-        <h1 class="page-title">{{ _('Customers') }}</h1>
-        <div class="action-buttons">
-            <a href="{{ url_for('customers.add_customer') }}" class="btn btn-primary">
-                + {{ _('Add Customer') }}
-            </a>
-            <a href="{{ url_for('dashboard.manager_dashboard' if session.get('role') in ['admin', 'manager'] else 'dashboard.dashboard') }}" class="dashboard-link">
-                ← {{ _('Back to Dashboard') }}
-            </a>
-        </div>
+<div class="page-header">
+  <div>
+    <h1 class="page-title">{{ _('Customers') }} <span>{{ total }} {{ _('total') }}</span></h1>
+  </div>
+  <div class="toolbar">
+    <!-- Search -->
+    <form method="get" action="" id="filterForm" class="search-box">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
+      <input type="text" name="search" id="searchInput"
+             value="{{ search_term or '' }}"
+             placeholder="{{ _('Search customers…') }}"
+             oninput="debounceSearch()">
+      <input type="hidden" name="stage" id="stageHidden" value="{{ current_stage or '' }}">
+    </form>
+
+    <!-- Stage filter -->
+    <select class="filter-select" id="stageSelect" onchange="applyStage(this.value)">
+      <option value="">{{ _('All Stages') }}</option>
+      {% for stage in sales_stages %}
+      <option value="{{ stage }}" {% if current_stage == stage %}selected{% endif %}>{{ stage }}</option>
+      {% endfor %}
+    </select>
+
+    <!-- View toggle -->
+    <div class="view-toggle">
+      <button class="view-btn" id="btnCards" onclick="setView('cards')" title="{{ _('Card view') }}">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+      </button>
+      <button class="view-btn" id="btnList" onclick="setView('list')" title="{{ _('List view') }}">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
+      </button>
     </div>
 
-    <div class="search-filter-container">
-        <input type="text" class="search-box" placeholder="{{ _('Search by company, contact, phone, or stage...') }}"
-               id="searchInput" value="{{ search_term or '' }}" onkeyup="debounceSearch()">
-        <select class="filter-select" id="stageFilter" onchange="applyFilters()">
-            <option value="">{{ _('All Stages') }}</option>
-            <option value="N/A" {% if current_stage == 'N/A' %}selected{% endif %}>N/A</option>
-            {% for stage in sales_stages %}
-            <option value="{{ stage }}" {% if current_stage == stage %}selected{% endif %}>{{ stage }}</option>
-            {% endfor %}
-        </select>
-    </div>
-
-    {% if customers %}
-    <div class="customer-grid">
-        {% for customer in customers %}
-        <div class="customer-card">
-            <div class="customer-header">
-                <a href="{{ url_for('customers.customer_detail', customer_id=customer.customer_id) }}" class="customer-name">
-                    {{ customer.company_name }}
-                </a>
-                <span class="customer-stage">{{ customer.current_sales_stage or 'N/A' }}</span>
-            </div>
-            <div class="customer-info">
-                <div class="info-row">
-                    <span class="info-label">{{ _('Contact') }}:</span>
-                    <span class="info-value">{{ customer.contact_person or 'N/A' }}</span>
-                </div>
-                <div class="info-row">
-                    <span class="info-label">{{ _('Phone') }}:</span>
-                    <span class="info-value">{{ customer.phone_number or 'N/A' }}</span>
-                </div>
-                <div class="info-row">
-                    <span class="info-label">{{ _('Industry') }}:</span>
-                    <span class="info-value">{{ customer.company_industry or 'N/A' }}</span>
-                </div>
-                <div class="info-row">
-                    <span class="info-label">{{ _('Potential Value') }}:</span>
-                    <span class="info-value potential-value">
-                        {{ customer.potential_value|default(0) }}
-                    </span>
-                </div>
-                <div class="info-row">
-                    <span class="info-label">{{ _('Last Contact') }}:</span>
-                    <span class="info-value">{{ customer.last_contact_date|default('N/A') }}</span>
-                </div>
-            </div>
-            <div class="customer-actions">
-                <a href="{{ url_for('customers.customer_detail', customer_id=customer.customer_id) }}" class="btn btn-primary">
-                    {{ _('View Details') }}
-                </a>
-                <a href="{{ url_for('follow_up.add_followup', customer_id=customer.customer_id) }}" class="btn btn-success">
-                    + {{ _('Add Follow-up') }}
-                </a>
-            </div>
-        </div>
-        {% endfor %}
-    </div>
-
-    <div class="pagination">
-        {% if page > 1 %}
-        <li class="page-item">
-            <a href="{{ url_for('customers.customer_list', page=page - 1) }}" class="page-link">&laquo;</a>
-        </li>
-        {% endif %}
-
-        {% for p in range(1, total_pages + 1) %}
-        <li class="page-item">
-            <a href="{{ url_for('customers.customer_list', page=p) }}" 
-               class="page-link {% if p == page %}active{% endif %}">
-                {{ p }}
-            </a>
-        </li>
-        {% endfor %}
-
-        {% if page < total_pages %}
-        <li class="page-item">
-            <a href="{{ url_for('customers.customer_list', page=page + 1) }}" class="page-link">&raquo;</a>
-        </li>
-        {% endif %}
-    </div>
-    {% else %}
-    <div class="empty-state">
-        <div class="empty-state-icon">📋</div>
-        <h2>{{ _('No customers found') }}</h2>
-        <p>{{ _('Add your first customer to get started') }}</p>
-    </div>
-    {% endif %}
+    <a href="{{ url_for('customers.add_customer') }}" class="btn btn-primary">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+      {{ _('Add Customer') }}
+    </a>
+  </div>
 </div>
-{% endblock %}
 
-{% block scripts %}
+{% if customers %}
+
+{# ── Cards view ── #}
+<div id="viewCards" class="cards-grid">
+  {% for c in customers %}
+  {%- set stage_lc = (c.current_sales_stage or '')|lower -%}
+  {%- if 'تم' in stage_lc or 'won' in stage_lc or 'تسليم' in stage_lc -%}
+    {%- set sbadge = 'stage-won' -%}
+  {%- elif 'لم' in stage_lc or 'lost' in stage_lc -%}
+    {%- set sbadge = 'stage-lost' -%}
+  {%- elif 'تفاوض' in stage_lc or 'negot' in stage_lc or 'عرض' in stage_lc -%}
+    {%- set sbadge = 'stage-hot' -%}
+  {%- elif 'جديد' in stage_lc or 'محتمل' in stage_lc or 'new' in stage_lc -%}
+    {%- set sbadge = 'stage-new' -%}
+  {%- else -%}
+    {%- set sbadge = '' -%}
+  {%- endif -%}
+  <div class="customer-card"
+       onclick="location.href='{{ url_for('customers.customer_detail', customer_id=c.customer_id) }}'">
+    <div class="card-top">
+      <div class="card-avatar">{{ (c.company_name or '?')[0]|upper }}</div>
+      <div class="card-info">
+        <div class="card-name">{{ c.company_name or '—' }}</div>
+        <div class="card-contact">{{ c.contact_person or '—' }}</div>
+      </div>
+      <span class="stage-badge {{ sbadge }}">{{ c.current_sales_stage or 'N/A' }}</span>
+    </div>
+
+    <div class="card-meta">
+      {% if c.phone_number %}
+      <span class="meta-chip">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07A19.5 19.5 0 0 1 4.36 12a19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 3.27 1h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L7.91 8.1a16 16 0 0 0 6 6l.62-.62a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/></svg>
+        {{ c.phone_number }}
+      </span>
+      {% endif %}
+      {% if c.company_industry %}
+      <span class="meta-chip">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>
+        {{ c.company_industry }}
+      </span>
+      {% endif %}
+      {% if c.salesperson_name %}
+      <span class="meta-chip">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+        {{ c.salesperson_name }}
+      </span>
+      {% endif %}
+    </div>
+
+    <div class="card-footer">
+      <div>
+        {% if c.potential_value %}
+        <div class="card-value">💰 {{ "{:,.0f}".format(c.potential_value) }}</div>
+        {% endif %}
+        {% if c.last_contact_date %}
+        <div class="card-date">{{ c.last_contact_date }}</div>
+        {% endif %}
+      </div>
+      <div class="card-actions" onclick="event.stopPropagation()">
+        <a href="{{ url_for('follow_up.add_followup', customer_id=c.customer_id) }}"
+           class="btn btn-success btn-sm">+ {{ _('Follow-up') }}</a>
+        <a href="{{ url_for('customers.edit_customer', customer_id=c.customer_id) }}"
+           class="btn btn-outline btn-sm">{{ _('Edit') }}</a>
+        <button class="btn btn-danger btn-sm"
+                onclick="deleteCustomer({{ c.customer_id }}, '{{ c.company_name|e }}')">{{ _('Delete') }}</button>
+      </div>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+
+{# ── List view ── #}
+<div id="viewList" class="list-table-wrap" style="display:none">
+  <table>
+    <thead>
+      <tr>
+        <th>{{ _('Company') }}</th>
+        <th>{{ _('Contact') }}</th>
+        <th>{{ _('Phone') }}</th>
+        <th>{{ _('Industry') }}</th>
+        <th>{{ _('Stage') }}</th>
+        <th>{{ _('Value') }}</th>
+        <th>{{ _('Last Contact') }}</th>
+        <th>{{ _('Actions') }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for c in customers %}
+      <tr>
+        <td class="td-name">
+          <a href="{{ url_for('customers.customer_detail', customer_id=c.customer_id) }}">{{ c.company_name or '—' }}</a>
+        </td>
+        <td>{{ c.contact_person or '—' }}</td>
+        <td>{{ c.phone_number or '—' }}</td>
+        <td>{{ c.company_industry or '—' }}</td>
+        <td>
+          <span class="badge" style="background:#f1f5f9;color:#475569">{{ c.current_sales_stage or 'N/A' }}</span>
+        </td>
+        <td>{% if c.potential_value %}<span style="color:#16a34a;font-weight:600">{{ "{:,.0f}".format(c.potential_value) }}</span>{% else %}—{% endif %}</td>
+        <td>{{ c.last_contact_date or '—' }}</td>
+        <td>
+          <div style="display:flex;gap:.4rem;flex-wrap:wrap">
+            <a href="{{ url_for('follow_up.add_followup', customer_id=c.customer_id) }}" class="btn btn-success btn-sm">+ {{ _('Follow-up') }}</a>
+            <a href="{{ url_for('customers.edit_customer', customer_id=c.customer_id) }}" class="btn btn-outline btn-sm">{{ _('Edit') }}</a>
+            <button class="btn btn-danger btn-sm" onclick="deleteCustomer({{ c.customer_id }}, '{{ c.company_name|e }}')">{{ _('Delete') }}</button>
+          </div>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+{% else %}
+<div class="empty-state">
+  <svg width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+  <p>{{ _('No customers yet. Add your first customer!') }}</p>
+  <a href="{{ url_for('customers.add_customer') }}" class="btn btn-primary" style="margin-top:1rem">{{ _('Add Customer') }}</a>
+</div>
+{% endif %}
+
+{% if total_pages > 1 %}
+<div class="pagination">
+  <a href="?page={{ page-1 }}&search={{ search_term or '' }}&stage={{ current_stage or '' }}"
+     class="page-link {% if page == 1 %}disabled{% endif %}">‹</a>
+  {% for p in range(1, total_pages+1) %}
+    <a href="?page={{ p }}&search={{ search_term or '' }}&stage={{ current_stage or '' }}"
+       class="page-link {% if p == page %}active{% endif %}">{{ p }}</a>
+  {% endfor %}
+  <a href="?page={{ page+1 }}&search={{ search_term or '' }}&stage={{ current_stage or '' }}"
+     class="page-link {% if page == total_pages %}disabled{% endif %}">›</a>
+</div>
+{% endif %}
+
 <script>
-    let searchTimeout;
+// ── View toggle ────────────────────────────────────────
+function setView(v) {
+  localStorage.setItem('customersView', v);
+  document.getElementById('viewCards').style.display = v === 'cards' ? '' : 'none';
+  document.getElementById('viewList').style.display  = v === 'list'  ? '' : 'none';
+  document.getElementById('btnCards').classList.toggle('active', v === 'cards');
+  document.getElementById('btnList').classList.toggle('active',  v === 'list');
+}
+document.addEventListener('DOMContentLoaded', function() {
+  setView(localStorage.getItem('customersView') || 'cards');
+});
 
-    function debounceSearch() {
-        clearTimeout(searchTimeout);
-        searchTimeout = setTimeout(applyFilters, 300);
-    }
+// ── Stage filter ───────────────────────────────────────
+function applyStage(val) {
+  document.getElementById('stageHidden').value = val;
+  document.getElementById('filterForm').submit();
+}
 
-    function applyFilters() {
-        const searchInput = document.getElementById('searchInput');
-        const stageFilter = document.getElementById('stageFilter');
-        const searchTerm = searchInput.value.trim();
-        const selectedStage = stageFilter.value;
-        
-        let url = '/customers/list?';
-        const params = [];
-        
-        if (searchTerm) params.push(`search=${encodeURIComponent(searchTerm)}`);
-        if (selectedStage) params.push(`stage=${encodeURIComponent(selectedStage)}`);
-        
-        const urlParams = new URLSearchParams(window.location.search);
-        const sortBy = urlParams.get('sort_by');
-        const order = urlParams.get('order');
-        if (sortBy) params.push(`sort_by=${encodeURIComponent(sortBy)}`);
-        if (order) params.push(`order=${encodeURIComponent(order)}`);
-        
-        url += params.join('&');
-        window.location.href = url;
-    }
+// ── Search debounce ────────────────────────────────────
+let _st;
+function debounceSearch() {
+  clearTimeout(_st);
+  _st = setTimeout(() => document.getElementById('filterForm').submit(), 400);
+}
+
+// ── Delete ─────────────────────────────────────────────
+function deleteCustomer(id, name) {
+  if (!confirm('{{ _("Delete") }} "' + name + '"?')) return;
+  const csrf = document.querySelector('meta[name="csrf-token"]').content;
+  fetch('/customers/' + id + '/delete', {
+    method: 'POST',
+    headers: { 'X-CSRFToken': csrf }
+  })
+  .then(r => r.json())
+  .then(data => {
+    if (data.success) location.reload();
+    else alert(data.message || 'Error');
+  });
+}
 </script>
 {% endblock %}


### PR DESCRIPTION
…l company auto-sync

UI redesign (customer_list.html):
- Same modern style as companies/projects: cards grid + list table toggle
- localStorage view persistence (customersView)
- Stage filter dropdown in toolbar alongside search
- Cards show: avatar initial, company name, contact person, stage badge (color-coded: won=green, lost=red, negotiation=amber, new=blue), phone, industry, salesperson, potential value, last contact date
- Edit + Delete + Follow-up buttons on each card and list row
- Consistent pagination with search/stage params preserved
- Total count in page header

Delete endpoint (routes/customers.py):
- POST /customers/<id>/delete — removes follow-ups, project_contacts, then customer
- AJAX-friendly JSON response

Auto-sync companies ↔ customers (bi-directional):
- add_customer / edit_customer: if company_name is set, find-or-create a matching company row and set customer.company_id automatically
- add_company: after creating the company, update any existing customers whose company_name matches (case-insensitive) and have no company_id yet